### PR TITLE
Update header-icon width

### DIFF
--- a/_sass/organisms/_global-header.scss
+++ b/_sass/organisms/_global-header.scss
@@ -60,6 +60,9 @@
     margin-top: .5rem;
     .subtitle { font-size: $small-font-size }
   }
+  .header-icon {
+    width: 25%;
+  }
 }
 
 .global-header-buttons {


### PR DESCRIPTION
Was abnormally large, especially on desktop - simple "width: 25%;" declaration.
Directly impacts the "_templates/home-chime.html" file and [page](https://v4.style.codeforamerica.org/patterns/templates/home-chime/) was working in prior.